### PR TITLE
only list supported cyphers

### DIFF
--- a/minion/plugins/ssl.py
+++ b/minion/plugins/ssl.py
@@ -82,6 +82,7 @@ class SSLPlugin(ExternalProcessPlugin):
         self.sslscan_stdout = ""
         self.sslscan_stderr = ""
         u = urlparse.urlparse(self.configuration['target'])
+        args = ["--no-failed"]
         args = ["--xml=%s/report.xml" % self.work_directory]
         args += ["%s:443" % u.hostname]
         self.spawn(sslscan_path, args)

--- a/minion/plugins/ssl.py
+++ b/minion/plugins/ssl.py
@@ -83,7 +83,7 @@ class SSLPlugin(ExternalProcessPlugin):
         self.sslscan_stderr = ""
         u = urlparse.urlparse(self.configuration['target'])
         args = ["--no-failed"]
-        args = ["--xml=%s/report.xml" % self.work_directory]
+        args += ["--xml=%s/report.xml" % self.work_directory]
         args += ["%s:443" % u.hostname]
         self.spawn(sslscan_path, args)
 


### PR DESCRIPTION
Only list accepted cyphers. Reduces loop count when checking for SSLv2 (or other checks that would loop through the cyphers, like a cypher strength check).

From sslscan's man page:

```
       --no-failed
              List only accepted ciphers (default is to listing all ciphers).
```
